### PR TITLE
Handle MultiIndex columns in Wikipedia changes parsing

### DIFF
--- a/data/tests/test_sp500.py
+++ b/data/tests/test_sp500.py
@@ -29,3 +29,15 @@ def test_prepare_time_series():
     ts = sp500.prepare_time_series(df)
     assert ts.shape[0] == 4
     assert list(ts.columns) == ["AAA"]
+
+
+def test_parse_wikipedia_changes_multiindex():
+    multiindex_changes = pd.DataFrame({
+        ("Date", ""): ["2024-01-01"],
+        ("Added", ""): ["DDD"],
+        ("Removed", ""): [None],
+    })
+
+    with mock.patch("data.src.sp500.pd.read_html", return_value=[multiindex_changes]):
+        tickers = sp500._parse_wikipedia_changes(240)
+    assert tickers == ["DDD"]


### PR DESCRIPTION
## Summary
- flatten column names when parsing the historical changes table from Wikipedia
- test support for parsing MultiIndex tables

## Testing
- `python -m py_compile data/src/sp500.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*